### PR TITLE
Fix build on GNU/Linux

### DIFF
--- a/nscryptoTests/main.cpp
+++ b/nscryptoTests/main.cpp
@@ -7,6 +7,9 @@
 //
 
 #include "nscrypto.h"
+#ifdef __linux__
+#include <bsd/stdlib.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -264,7 +267,6 @@ TEST_CASE("nscrypto ecdh", "[nscrypto]") {
                 REQUIRE(vp_eph != NULL);
                 REQUIRE(VP_EC_KEY_export_public(vp_eph) == eph);
                 
-                //string decrypted(ecdh_server_decrypt(r_priv, s_pub, s_id, r_id, encrypted));
                 string decrypted(VP_ECDH_decrypt(vp_r_priv, vp_s_pub, vp_eph, s_id, r_id, string("\x00\x00\x00\x01", 4), enc, tag));
                 
                 REQUIRE(!decrypted.empty());
@@ -308,7 +310,7 @@ TEST_CASE("nscrypto ecdh", "[nscrypto]") {
                 string eph(VP_EC_KEY_export_public(vp_eph));
                 REQUIRE(!eph.empty());
                 
-                string decrypted(ecdh_server_decrypt(r_priv, s_pub, s_id, r_id, {enc, tag, eph}));
+                string decrypted(ecdh_server_decrypt(r_priv, s_pub, s_id, r_id, ecdh_encrypted_t{enc,tag,eph}));
                 REQUIRE(!decrypted.empty());
                 REQUIRE(decrypted == msg);
                 
@@ -326,7 +328,7 @@ TEST_CASE("nscrypto ecdh", "[nscrypto]") {
                 string eph(VP_EC_KEY_export_public(vp_eph));
                 REQUIRE(!eph.empty());
                 
-                string decrypted(ecdh_client_decrypt(r_priv, s_pub, s_id, r_id, {enc, tag, eph}));
+                string decrypted(ecdh_client_decrypt(r_priv, s_pub, s_id, r_id, ecdh_encrypted_t {enc, tag, eph}));
                 REQUIRE(!decrypted.empty());
                 REQUIRE(decrypted == msg);
                 


### PR DESCRIPTION
Notes:
- Confirmed that it builds fine against libressl
- Requires libbsd, libcxx, libc++, libcrypto and libssl.
- Only builds with CLANG, G++ fails with lot of errors
