### PR TITLE
Add Makefiles for GNU/Linux compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SUBDIRS=nscrypto nscryptoTests
+
+define MAKEALL
+	$(foreach d,$(SUBDIRS),$(MAKE) -C $(d) $1;)
+endef
+
+all:
+	$(call MAKEALL,all)
+
+clean:
+	$(call MAKEALL,clean)

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,15 @@
+LIBBSD_CF=$(shell pkg-config --cflags libbsd)
+LIBBSD_LF=$(shell pkg-config --libs libbsd)
+
+LDFLAGS+=-lssl -lcrypto -lc++ -lbsd
+CXXFLAGS+=-I/usr/include/libressl
+CXXFLAGS+=-I. -I../include -I../nscrypto -g
+AR?=ar
+RANLIB?=ranlib
+
+# CLANG
+CXX=clang++
+CXXFLAGS+=-stdlib=libc++ -std=c++11
+
+# G++ cannot compile this code
+#CXX=g++

--- a/nscrypto/Makefile
+++ b/nscrypto/Makefile
@@ -1,0 +1,13 @@
+include ../config.mk
+
+all: libnscrypto.a
+
+libnscrypto.a: nscrypto_ecdh.o
+	$(AR) -r libnscrypto.a nscrypto_ecdh.o
+	$(RANLIB) libnscrypto.a
+
+$(OBJS): %.o: %.cc
+	$(CXX) -o $@ -c ${CXXFLAGS} $<
+
+clean:
+	rm -f libnscrypto.a nscrypto_ecdh.o

--- a/nscryptoTests/Makefile
+++ b/nscryptoTests/Makefile
@@ -1,0 +1,18 @@
+include ../config.mk
+
+OBJS=main.o vp_ecdh.o
+LIBS=../nscrypto/libnscrypto.a
+
+all: main
+
+main: $(OBJS) $(LIBS)
+	$(CXX) -o $@ $(LDFLAGS) $(OBJS) $(LIBS)
+
+$(OBJS): %.o: %.cpp
+	${CXX} -o $@ -c ${CXXFLAGS} $<
+
+../nscrypto/libnscrypto.a:
+	$(MAKE) -C ../nscrypto
+
+clean:
+	rm -f $(OBJS)


### PR DESCRIPTION
Tested on linux with latest libcxx and clang-3.6. But the test fails to run with an unknown exception:
(didnt tested on osx yet)

```
$ ./main
length = 1
uncaught_exception not yet implemented
Aborted
```
